### PR TITLE
Add support for CSV without headers row

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/rocketlaunchr/mysql-go v1.1.3
 	github.com/sandertv/go-formula/v2 v2.0.0-alpha.7
 	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/stretchr/testify v1.5.1
 	github.com/tealeg/xlsx/v3 v3.0.0
 	github.com/wcharczuk/go-chart v2.0.1+incompatible
 	github.com/xitongsys/parquet-go v1.5.2

--- a/imports/csv_test.go
+++ b/imports/csv_test.go
@@ -1,0 +1,101 @@
+// Copyright 2018-20 PJ Engineering and Business Solutions Pty. Ltd. All rights reserved.
+
+package imports
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	dataframe "github.com/rocketlaunchr/dataframe-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertEqualDS(t *testing.T, want *dataframe.DataFrame, got *dataframe.DataFrame) {
+	assert.Equal(t, len(want.Series), len(got.Series))
+	assert.Equal(t, want.NRows(), got.NRows())
+	for i := 0; i < len(want.Series); i++ {
+		assert.Equal(t, want.Series[i].NRows(), got.Series[i].NRows())
+
+		for j := 0; j < want.NRows(); j++ {
+			assert.Equal(t, want.Series[i].Value(j), got.Series[i].Value(j))
+		}
+	}
+}
+
+func TestLoadFromCSV(t *testing.T) {
+	type args struct {
+		file    string
+		options CSVLoadOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *dataframe.DataFrame
+		wantErr bool
+	}{
+		{
+			name: "Should parse valid CSV",
+			args: args{
+				file: "valid.csv",
+			},
+			want: dataframe.NewDataFrame(
+				dataframe.NewSeriesString("time", nil, "1", "2", "3", "4", "5"),
+				dataframe.NewSeriesString("text", nil, "col2-1", "col2-2", "col2-3", "col2-4", "col2-5"),
+				dataframe.NewSeriesString("decimal", nil, "0.1", "0.2", "0.3", "0.4", "0.5"),
+				dataframe.NewSeriesString("boolean", nil, "false", "true", "false", "true", "false"),
+			),
+		},
+		{
+			name: "Should parse valid CSV, without headers",
+			args: args{
+				file: "valid_without_headers.csv",
+				options: CSVLoadOptions{
+					ColumnNames: []string{"time-nh", "text-nh", "decimal-nh", "boolean-nh"},
+				},
+			},
+			want: dataframe.NewDataFrame(
+				dataframe.NewSeriesString("time-nh", nil, "11", "12", "13", "14", "15"),
+				dataframe.NewSeriesString("text-nh", nil, "col2-11", "col2-12", "col2-13", "col2-14", "col2-15"),
+				dataframe.NewSeriesString("decimal-nh", nil, "1.1", "1.2", "1.3", "1.4", "1.5"),
+				dataframe.NewSeriesString("boolean-nh", nil, "false", "true", "false", "true", "false"),
+			),
+		},
+		{
+			name: "Should parse valid CSV, with specified type",
+			args: args{
+				file: "valid.csv",
+				options: CSVLoadOptions{
+					DictateDataType: map[string]interface{}{
+						"time":    time.Time{},
+						"text":    "",
+						"decimal": float64(0),
+						"boolean": false,
+					},
+				},
+			},
+			want: dataframe.NewDataFrame(
+				dataframe.NewSeriesTime("time", nil, time.Unix(1, 0), time.Unix(2, 0), time.Unix(3, 0), time.Unix(4, 0), time.Unix(5, 0)),
+				dataframe.NewSeriesString("text", nil, "col2-1", "col2-2", "col2-3", "col2-4", "col2-5"),
+				dataframe.NewSeriesFloat64("decimal", nil, 0.1, 0.2, 0.3, 0.4, 0.5),
+				dataframe.NewSeriesInt64("boolean", nil, 0, 1, 0, 1, 0),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := os.Open(filepath.Join("testdata", tt.args.file))
+			assert.Nil(t, err)
+
+			got, err := LoadFromCSV(context.TODO(), file, tt.args.options)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadFromCSV() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			assertEqualDS(t, tt.want, got)
+		})
+	}
+}

--- a/imports/testdata/valid.csv
+++ b/imports/testdata/valid.csv
@@ -1,0 +1,6 @@
+time,text,decimal,boolean
+1,col2-1,0.1,false
+2,col2-2,0.2,true
+3,col2-3,0.3,false
+4,col2-4,0.4,true
+5,col2-5,0.5,false

--- a/imports/testdata/valid_without_headers.csv
+++ b/imports/testdata/valid_without_headers.csv
@@ -1,0 +1,5 @@
+11,col2-11,1.1,false
+12,col2-12,1.2,true
+13,col2-13,1.3,false
+14,col2-14,1.4,true
+15,col2-15,1.5,false


### PR DESCRIPTION
This simply adds the support to import CSV files without a headers row.

In case the `ColumnNames` options is specified, it uses it to set the series names, instead of reading the first row.

It moves the `if row == 0 {` outside the for loop to avoid to do the check for each row read.