### PR TITLE
Improve memory use by setting map capacity in dataframe.Row()

### DIFF
--- a/dataframe.go
+++ b/dataframe.go
@@ -88,7 +88,7 @@ func (df *DataFrame) Row(row int, dontReadLock bool, retOpt ...SeriesReturnOpt) 
 		defer df.lock.RUnlock()
 	}
 
-	out := map[interface{}]interface{}{}
+	out := make(map[interface{}]interface{}, len(df.Series))
 
 	for idx, aSeries := range df.Series {
 		val := aSeries.Value(row)


### PR DESCRIPTION
I noticed this while benchmarking with funcs.Evaluate. Here's my before and after for a 45x45 dataframe of float64s with an expression that uses all 45 columns.

```
BenchmarkFuncEvaluateOriginal-10     	     9235	    625042 ns/op	  853558 B/op	    7564 allocs/op
BenchmarkFuncEvaluateWithMemoryRes-10    	10000	    567637 ns/op	  754678 B/op	    7401 allocs/op
```