### PR TITLE
fix: holt-winters train.go runs off end of series and panics if start > 0

### DIFF
--- a/forecast/algs/hw/train.go
+++ b/forecast/algs/hw/train.go
@@ -28,6 +28,8 @@ func (hw *HoltWinters) trainSeries(ctx context.Context, start, end int) error {
 	)
 
 	y := hw.sf.Values[start : end+1]
+	y_start := 0
+	y_end := len(y) - 1
 
 	seasonals := initialSeasonalComponents(y, period, hw.cfg.SeasonalMethod)
 
@@ -39,14 +41,14 @@ func (hw *HoltWinters) trainSeries(ctx context.Context, start, end int) error {
 	var mse float64 // mean squared error
 
 	// Training smoothing Level
-	for i := start; i < end+1; i++ {
+	for i := y_start; i < y_end+1; i++ {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
 		xt := y[i]
 
-		if i == start { // Set initial smooth
+		if i == y_start { // Set initial smooth
 			st = xt
 			hw.tstate.initialSmooth = xt
 		} else {


### PR DESCRIPTION
holt-winters train.go runs off end of series and panics if Range.Start

The indexing limits used in the for loop are intended for hw.sf.Values, but since we are indexing into "y" instead, we run off the end of the array and panic if start > 0. 

To fix this, we create a y_start and y_end and use those as limits and within the function in place of start and end. 